### PR TITLE
some fixes 

### DIFF
--- a/baseConfig/adventurer/configuration.nix
+++ b/baseConfig/adventurer/configuration.nix
@@ -90,8 +90,8 @@
 
   # Configure keymap in X11
   services.xserver = {
-    layout = "us";
-    xkbVariant = "";
+    xkb.layout = "us";
+    xkb.Variant = "";
   };
 
   # Configure console keymap

--- a/baseConfig/adventurer/configuration.nix
+++ b/baseConfig/adventurer/configuration.nix
@@ -91,7 +91,7 @@
   # Configure keymap in X11
   services.xserver = {
     xkb.layout = "us";
-    xkb.Variant = "";
+    xkb.variant = "";
   };
 
   # Configure console keymap

--- a/baseConfig/adventurer/configuration.nix
+++ b/baseConfig/adventurer/configuration.nix
@@ -8,6 +8,7 @@
   imports =
     [ # Include the results of the hardware scan.
       ./hardware-configuration.nix
+      ../substituters.nix
     ];
 
   # Bootloader.

--- a/baseConfig/adventurer/configuration.nix
+++ b/baseConfig/adventurer/configuration.nix
@@ -63,10 +63,9 @@
   # You can disable this if you're only using the Wayland session.
   services.xserver.enable = true;
   services.xserver.videoDrivers = [ "nouveau" ];
-  hardware.opengl = {
+  hardware.graphics = {
     enable = true;
-    driSupport = true;
-    driSupport32Bit = true;
+    enable32Bit = true;
     extraPackages = with pkgs; [
       mesa
       mesa.drivers
@@ -102,7 +101,6 @@
   services.printing.enable = true;
 
   # Enable sound with pipewire.
-  hardware.pulseaudio.enable = false;
   security.rtkit.enable = true;
   services.pipewire = {
     enable = true;
@@ -129,8 +127,6 @@
     #  thunderbird
     ];
   };
-
-  # Install firefox.
 
   # Allow unfree packages
   nixpkgs.config.allowUnfree = true;

--- a/baseConfig/adventurer/hardware-configuration.nix
+++ b/baseConfig/adventurer/hardware-configuration.nix
@@ -29,6 +29,6 @@
   # networking.interfaces.wlp12s0.useDHCP = lib.mkDefault true;
 
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
-  networking.enableIntel3945ABGFirmware = true;
+  hardware.enableRedistributableFirmware = true;
   hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
 }

--- a/baseConfig/hypermac/configuration.nix
+++ b/baseConfig/hypermac/configuration.nix
@@ -10,9 +10,7 @@
       ./hardware-configuration.nix
     ];
 
-#  programs.hyprland.enable = true;
   programs.gamemode.enable = true;
-  # Use the systemd-boot EFI boot loader.
   boot.loader = {
     efi.canTouchEfiVariables = false;
     grub = {
@@ -65,10 +63,9 @@
   services.xserver.enable = true;
   nixpkgs.config.allowUnfree = true;
   services.xserver.videoDrivers = [ "nouveau" ];  
-  hardware.opengl = {
+  hardware.graphics = {
     enable = true;
-    driSupport = true;
-    driSupport32Bit = true;
+    enable32Bit = true;
     extraPackages = with pkgs; [
       mesa
       mesa.drivers
@@ -111,8 +108,6 @@
     jack.enable = true;
   };
   programs.dconf.enable = true;
-  # Enable touchpad support (enabled default in most desktopManager).
-  # services.xserver.libinput.enable = true;
 
   # Define a user account. Don't forget to set a password with ‘passwd’.
   users.users.maya = {
@@ -152,7 +147,6 @@
   # networking.firewall.allowedUDPPorts = [ ... ];
   # Or disable the firewall altogether.
   # networking.firewall.enable = false;
-
   # Copy the NixOS configuration file and link it from the resulting system
   # (/run/current-system/configuration.nix). This is useful in case you
   # accidentally delete configuration.nix.

--- a/baseConfig/hypermac/configuration.nix
+++ b/baseConfig/hypermac/configuration.nix
@@ -8,6 +8,7 @@
   imports =
     [ # Include the results of the hardware scan.
       ./hardware-configuration.nix
+      ../substituters.nix
     ];
 
   programs.gamemode.enable = true;

--- a/baseConfig/substituters.nix
+++ b/baseConfig/substituters.nix
@@ -1,0 +1,22 @@
+{
+  inputs,
+  config,
+  pkgs,
+  lib,
+  ...
+}: {
+
+  nix.settings.substituters = [
+    "https://nix-community.cachix.org"
+    "https://hyprland.cachix.org"
+    "https://nixpkgs-wayland.cachix.org"
+    "https://cache.garnix.io"
+  ];
+
+  nix.settings.trusted-public-keys = [
+    "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+    "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc="
+    "nixpkgs-wayland.cachix.org-1:3lwxaILxMRkVhehr5StQprHdEo4IrE8sRho9R9HOLYA="
+    "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
+  ];
+};

--- a/baseConfig/substituters.nix
+++ b/baseConfig/substituters.nix
@@ -19,4 +19,4 @@
     "nixpkgs-wayland.cachix.org-1:3lwxaILxMRkVhehr5StQprHdEo4IrE8sRho9R9HOLYA="
     "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
   ];
-};
+}

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718788307,
-        "narHash": "sha256-SqiOz0sljM0GjyQEVinPXQxaGcbOXw5OgpCWGPgh/vo=",
+        "lastModified": 1720045378,
+        "narHash": "sha256-lmE7B+QXw7lWdBu5GQlUABSpzPk3YBb9VbV+IYK5djk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d7830d05421d0ced83a0f007900898bdcaf2a2ca",
+        "rev": "0a30138c694ab3b048ac300794c2eb599dc40266",
         "type": "github"
       },
       "original": {
@@ -60,11 +60,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1718835324,
-        "narHash": "sha256-U5eKTPAXppfSIqKqMIgbyuTBy1gr2seSOUl8sUSR8FE=",
+        "lastModified": 1720092067,
+        "narHash": "sha256-ebMlTz4wm+Md5BkCk6uGcRUvOvyjtc4bENvVSO5jrBI=",
         "ref": "refs/heads/main",
-        "rev": "fabc30df52ab5d2c369fc8acd4ff909a6ba3b8ac",
-        "revCount": 4870,
+        "rev": "0a6e83005f1910b5c1ec78476fcffc05af47833a",
+        "revCount": 4906,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/hyprwm/Hyprland"
@@ -143,11 +143,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718804078,
-        "narHash": "sha256-CqRZne63BpYlPd/i8lXV0UInUt59oKogiwdVtBRHt60=",
+        "lastModified": 1719316102,
+        "narHash": "sha256-dmRz128j/lJmMuTYeCYPfSBRHHQO3VeH4PbmoyAhHzw=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "4f1351295c55a8f51219b25aa4a6497a067989d0",
+        "rev": "1f6bbec5954f623ff8d68e567bddcce97cd2f085",
         "type": "github"
       },
       "original": {
@@ -168,11 +168,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718119275,
-        "narHash": "sha256-nqDYXATNkyGXVmNMkT19fT4sjtSPBDS1LLOxa3Fueo4=",
+        "lastModified": 1719067853,
+        "narHash": "sha256-mAnZG/eQy72Fp1ImGtqCgUrDumnR1rMZv2E/zgP4U74=",
         "owner": "hyprwm",
         "repo": "hyprwayland-scanner",
-        "rev": "1419520d5f7f38d35e05504da5c1b38212a38525",
+        "rev": "914f083741e694092ee60a39d31f693d0a6dc734",
         "type": "github"
       },
       "original": {
@@ -183,11 +183,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1718530797,
-        "narHash": "sha256-pup6cYwtgvzDpvpSCFh1TEUjw2zkNpk8iolbKnyFmmU=",
+        "lastModified": 1719075281,
+        "narHash": "sha256-CyyxvOwFf12I91PBWz43iGT1kjsf5oi6ax7CrvaMyAo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b60ebf54c15553b393d144357375ea956f89e9a9",
+        "rev": "a71e967ef3694799d0c418c98332f7ff4cc5f6af",
         "type": "github"
       },
       "original": {
@@ -199,11 +199,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1718530797,
-        "narHash": "sha256-pup6cYwtgvzDpvpSCFh1TEUjw2zkNpk8iolbKnyFmmU=",
+        "lastModified": 1719848872,
+        "narHash": "sha256-H3+EC5cYuq+gQW8y0lSrrDZfH71LB4DAf+TDFyvwCNA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b60ebf54c15553b393d144357375ea956f89e9a9",
+        "rev": "00d80d13810dbfea8ab4ed1009b09100cca86ba8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
changes: update flake.lock, correct changed options, add substituters

1: self explanatory

2: hardware.opengl is now hardware.graphics, hardware.opengl.driSupport has been deprecated, hardware.opengl.driSupport32Bit is now hardware.graphics.enable32Bit. xkbVariant is now services.xserver.xkb.variant and services.xserver.layout is now services.xserver.xkb.layout. networking.enableIntel3945ABGFirmware is now covered by hardware.enableRedistributableFirmware.

3: under baseConfigs now exists substituters.nix, this adds substituters to both hypermac and adventurer so in the off chance you add something not in nixpkgs it will pull from these substituters.