### PR TITLE
Update home-manager.nix

### DIFF
--- a/modules/hm/home-manager.nix
+++ b/modules/hm/home-manager.nix
@@ -20,7 +20,7 @@
       gtk = {
         enable = true;
 	theme = {
-	  name = "catppuccin-mocha-mauve-standard+default";
+	  name = "catppuccin-mocha-mauve-standard";
 	  package = pkgs.catppuccin-gtk.override {
 	    accents = ["mauve"];
             size = "standard";


### PR DESCRIPTION
fixes catppuccin (fr this time) tldr is the catppuccin devs are 'change the theme name' happy so it changed within the time i fixed it and the time i flake updated this repository.